### PR TITLE
Put back pedometer_steps

### DIFF
--- a/adafruit_lsm6ds.py
+++ b/adafruit_lsm6ds.py
@@ -196,6 +196,7 @@ class LSM6DS:  # pylint: disable=too-many-instance-attributes
 
     # ROUnaryStructs:
     _chip_id = ROUnaryStruct(_LSM6DS_WHOAMI, "<b")
+    pedometer_steps = ROUnaryStruct(_LSM6DS_STEP_COUNTER, "<h")
 
     # Structs
     _raw_accel_data = Struct(_LSM6DS_OUTX_L_A, "<hhh")


### PR DESCRIPTION
Possible fix for #21 

Simply puts back the class level ROUnaryStruct register for steps. Looks like this was accidentally removed during a refactor in #16. Since that PR seems to be related to conserving memory, not sure if this is the desired solution. But it checks out:
```python
Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit CLUE nRF52840 Express with nRF52840
>>> import board
>>> from adafruit_lsm6ds import LSM6DS33
>>> sensor = LSM6DS33(board.I2C())
>>> sensor.pedometer_enable = True
>>> sensor.pedometer_steps
0
>>> sensor.pedometer_steps
10
>>> 
```