### PR TITLE
Add LSM6DS3 subclass

### DIFF
--- a/adafruit_lsm6ds/lsm6ds3.py
+++ b/adafruit_lsm6ds/lsm6ds3.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020 Bryan Siepert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+This module provides the `adafruit_lsm6ds.lsm6ds3` subclass of LSM6DS sensors
+===============================================================================
+"""
+from . import LSM6DS
+
+
+class LSM6DS3(LSM6DS):  # pylint: disable=too-many-instance-attributes
+
+    """Driver for the LSM6DS3 6-axis accelerometer and gyroscope.
+
+    :param ~busio.I2C i2c_bus: The I2C bus the LSM6DS3 is connected to.
+    :param int address: The I2C device address. Defaults to :const:`0x6A`
+
+
+    **Quickstart: Importing and using the device**
+
+        Here is an example of using the :class:`LSM6DS3` class.
+        First you will need to import the libraries to use the sensor
+
+        .. code-block:: python
+
+            import board
+            from adafruit_lsm6ds.lsm6ds3 import LSM6DS3
+
+        Once this is done you can define your `board.I2C` object and define your sensor object
+
+        .. code-block:: python
+
+            i2c = board.I2C()  # uses board.SCL and board.SDA
+            sensor = LSM6DS3(i2c)
+
+        Now you have access to the :attr:`acceleration` and :attr:`gyro`: attributes
+
+        .. code-block:: python
+
+            acc_x, acc_y, acc_z = sensor.acceleration
+            gyro_x, gyro_y, gyro_z = sensor.gyro
+
+    """
+
+    CHIP_ID = 0x6A


### PR DESCRIPTION
This adds the LSM6DS3 class which is a copy of the LSM6DS33 class with a different chip ID. This makes the library work on the [Seeed XIAO nRF52840 Sense](https://circuitpython.org/board/Seeed_XIAO_nRF52840_Sense/) board. More info on the IMU can be found in the [Seeed Wiki](https://wiki.seeedstudio.com/XIAO-BLE-Sense-IMU-Usage/)

Tested with "Adafruit CircuitPython 7.2.0-alpha.2 on 2022-02-11; Seeed XIAO nRF52840 Sense with nRF52840"

```
import board
import busio
import digitalio

from adafruit_lsm6ds.lsm6ds3 import LSM6DS3

# Enable power to the IMU
imupwr = digitalio.DigitalInOut(board.IMU_PWR)
imupwr.direction = digitalio.Direction.OUTPUT
imupwr.value = True

# Create an I2C bus with the IMU pins
imu_i2c = busio.I2C(board.IMU_SCL, board.IMU_SDA)
sensor = LSM6DS3(imu_i2c)
```

Now the sensor values can be read like the example shows:
```
>>> acc_x, acc_y, acc_z = sensor.acceleration
>>> gyro_x, gyro_y, gyro_z = sensor.gyro

>>> print(f"accX: {acc_x} accY: {acc_y} accZ: {acc_z}")
accX: -0.165105 accY: -0.0885344 accZ: 10.0822
>>> print(f"gyroX: {gyro_x} gyroY: {gyro_y} gyroZ: {gyro_z}")
gyroX: 0.0129809 gyroY: -0.0316123 gyroZ: -0.00458149
```