### PR TITLE
Fixed LSM6DS3 to LSM6DS3TR-C

### DIFF
--- a/adafruit_lsm6ds/lsm6ds3trc.py
+++ b/adafruit_lsm6ds/lsm6ds3trc.py
@@ -9,6 +9,7 @@ from . import LSM6DS, RWBit, const
 
 _LSM6DS_CTRL10_C = const(0x19)
 
+
 class LSM6DS3TRC(LSM6DS):  # pylint: disable=too-many-instance-attributes
 
     """Driver for the LSM6DS3TR-C 6-axis accelerometer and gyroscope.

--- a/adafruit_lsm6ds/lsm6ds3trc.py
+++ b/adafruit_lsm6ds/lsm6ds3trc.py
@@ -2,36 +2,37 @@
 #
 # SPDX-License-Identifier: MIT
 """
-This module provides the `adafruit_lsm6ds.lsm6ds3` subclass of LSM6DS sensors
+This module provides the `adafruit_lsm6ds.lsm6ds3trc` subclass of LSM6DS sensors
 ===============================================================================
 """
-from . import LSM6DS
+from . import LSM6DS, RWBit, const
 
+_LSM6DS_CTRL10_C = const(0x19)
 
-class LSM6DS3(LSM6DS):  # pylint: disable=too-many-instance-attributes
+class LSM6DS3TRC(LSM6DS):  # pylint: disable=too-many-instance-attributes
 
-    """Driver for the LSM6DS3 6-axis accelerometer and gyroscope.
+    """Driver for the LSM6DS3TR-C 6-axis accelerometer and gyroscope.
 
-    :param ~busio.I2C i2c_bus: The I2C bus the LSM6DS3 is connected to.
+    :param ~busio.I2C i2c_bus: The I2C bus the LSM6DS3TR-C is connected to.
     :param int address: The I2C device address. Defaults to :const:`0x6A`
 
 
     **Quickstart: Importing and using the device**
 
-        Here is an example of using the :class:`LSM6DS3` class.
+        Here is an example of using the :class:`LSM6DS3TRC` class.
         First you will need to import the libraries to use the sensor
 
         .. code-block:: python
 
             import board
-            from adafruit_lsm6ds.lsm6ds3 import LSM6DS3
+            from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC
 
         Once this is done you can define your `board.I2C` object and define your sensor object
 
         .. code-block:: python
 
             i2c = board.I2C()  # uses board.SCL and board.SDA
-            sensor = LSM6DS3(i2c)
+            sensor = LSM6DS3TRC(i2c)
 
         Now you have access to the :attr:`acceleration` and :attr:`gyro`: attributes
 
@@ -43,3 +44,7 @@ class LSM6DS3(LSM6DS):  # pylint: disable=too-many-instance-attributes
     """
 
     CHIP_ID = 0x6A
+
+    # This version of the IMU has a different register for enabling the pedometer
+    # https://www.st.com/resource/en/datasheet/lsm6ds3tr-c.pdf
+    _ped_enable = RWBit(_LSM6DS_CTRL10_C, 4)

--- a/examples/lsm6ds_lsm6ds3trc_simpletest.py
+++ b/examples/lsm6ds_lsm6ds3trc_simpletest.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020 Bryan Siepert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+import time
+import board
+import digitalio
+import busio
+from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC
+
+# On the Seeed XIAO nRF52840 Sense the LSM6DS3TR-C IMU is connected on a separate
+# I2C bus and it has its own power pin that we need to enable.
+imupwr = digitalio.DigitalInOut(board.IMU_PWR)
+imupwr.direction = digitalio.Direction.OUTPUT
+imupwr.value = True
+
+imu_i2c = busio.I2C(board.IMU_SCL, board.IMU_SDA)
+sensor = LSM6DS3TRC(imu_i2c)
+
+while True:
+    print("Acceleration: X:%.2f, Y: %.2f, Z: %.2f m/s^2" % (sensor.acceleration))
+    print("Gyro X:%.2f, Y: %.2f, Z: %.2f radians/s" % (sensor.gyro))
+    print("")
+    time.sleep(0.5)


### PR DESCRIPTION
Originally I read that the "Seeed XIAO nRF52840 Sense" had an LSM6DS3 IMU, but upon further testing, it's actually an LSM6DS3TR-C model so I changed this class to match the chip id to the correct one. The specific sensor model is mentioned in the [listing](https://www.seeedstudio.com/Seeed-XIAO-BLE-Sense-nRF52840-p-5253.html) and [wiki article](https://wiki.seeedstudio.com/XIAO_BLE/#features).

I've added an example for using the library with the XIAO BLE Sense board which is using a separate IMU I2C bus and an IMU_PWR pin to enable the IMU.

Also now the pedometer example works with this board using the correct register.
```
Adafruit CircuitPython 7.2.0-rc.2 on 2022-02-23; Seeed XIAO nRF52840 Sense with nRF52840
>>>
>>> import board
>>> import digitalio
>>> import busio
>>> from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC
>>>
>>> # On the Seeed XIAO nRF52840 Sense the LSM6DS3TR-C IMU is connected on a separate
>>> # I2C bus and it has its own power pin that we need to enable.
>>> imupwr = digitalio.DigitalInOut(board.IMU_PWR)
>>> imupwr.direction = digitalio.Direction.OUTPUT
>>> imupwr.value = True
>>>
>>> imu_i2c = busio.I2C(board.IMU_SCL, board.IMU_SDA)
>>> sensor = LSM6DS3TRC(imu_i2c)
>>>
>>>
>>> sensor.pedometer_enable = True
>>>
>>> print("Steps: ", sensor.pedometer_steps)
Steps:  0
>>> print("Steps: ", sensor.pedometer_steps)
Steps:  0
>>> print("Steps: ", sensor.pedometer_steps)
Steps:  7
>>> print("Steps: ", sensor.pedometer_steps)
Steps:  9
>>> print("Steps: ", sensor.pedometer_steps)
Steps:  11
```