### PR TITLE
Add access to MLC for LSM6DSOX

### DIFF
--- a/adafruit_lsm6ds/lsm6dsox.py
+++ b/adafruit_lsm6ds/lsm6dsox.py
@@ -50,6 +50,8 @@ class LSM6DSOX(LSM6DS):  # pylint: disable=too-many-instance-attributes
 
     CHIP_ID = LSM6DS_CHIP_ID
 
-    def __init__(self, i2c_bus: I2C, address: int = LSM6DS_DEFAULT_ADDRESS) -> None:
-        super().__init__(i2c_bus, address)
+    def __init__(
+        self, i2c_bus: I2C, address: int = LSM6DS_DEFAULT_ADDRESS, ucf: str = None
+    ) -> None:
+        super().__init__(i2c_bus, address, ucf)
         self._i3c_disable = True

--- a/examples/lsm6ds_lsm6dsox_mlc_test.py
+++ b/examples/lsm6ds_lsm6dsox_mlc_test.py
@@ -7,6 +7,7 @@
 # NOTE: The pre-trained models (UCF files) for the examples can be found here:
 # https://github.com/STMicroelectronics/STMems_Machine_Learning_Core/tree/master/application_examples/lsm6dsox
 
+import time
 import board
 from adafruit_lsm6ds.lsm6dsox import LSM6DSOX
 from adafruit_lsm6ds import Rate, AccelRange, GyroRange
@@ -23,11 +24,28 @@ lsm.gyro_range = GyroRange.RANGE_2000_DPS
 lsm.accelerometer_range = AccelRange.RANGE_4G
 lsm.accelerometer_data_rate = Rate.RATE_26_HZ
 lsm.gyro_data_rate = Rate.RATE_26_HZ
+
+
 # Head gestures example
 # UCF_FILE = "lsm6dsox_head_gestures.ucf"
 # UCF_LABELS = {0:"Nod", 1:"Shake", 2:"Stationary", 3:"Swing", 4:"Walk"}
 # NOTE: Selected data rate and scale must match the MLC data rate and scale.
-# lsm = LSM6DSOX(i2c, gyro_odr=26, accel_odr=26, gyro_scale=250, accel_scale=2, ucf=UCF_FILE)
+# lsm = LSM6DSOX(i2c, ucf=UCF_FILE)
+# lsm.gyro_range = GyroRange.RANGE_250_DPS
+# lsm.accelerometer_range = AccelRange.RANGE_2G
+# lsm.accelerometer_data_rate = Rate.RATE_26_HZ
+# lsm.gyro_data_rate = Rate.RATE_26_HZ
+
+# 6 DOF Position example
+# UCF_FILE = "lsm6dsox_six_d_position.ucf"
+# UCF_LABELS = {0:"None", 1:"X-UP", 2:"X-DOWN", 3:"Y-UP", 4:"Y-DOWN", 5:"Z-UP", 6:"Z-DOWN"}
+# NOTE: Selected data rate and scale must match the MLC data rate and scale.
+# lsm = LSM6DSOX(i2c, ucf=UCF_FILE)
+# lsm.gyro_range = GyroRange.RANGE_250_DPS
+# lsm.accelerometer_range = AccelRange.RANGE_2G
+# lsm.accelerometer_data_rate = Rate.RATE_26_HZ
+# lsm.gyro_data_rate = Rate.RATE_26_HZ
+
 
 print("MLC configured...")
 
@@ -35,3 +53,7 @@ while True:
     buf = lsm.read_mlc_output()
     if buf is not None:
         print(UCF_LABELS[buf[0]])
+        # delay to allow interrupt flag to clear
+        # interrupt stays high for one sample interval
+        # (38.4 ms @ 26 Hz ot 19.2 ms @ 52Hz)
+        time.sleep(0.05)

--- a/examples/lsm6ds_lsm6dsox_mlc_test.py
+++ b/examples/lsm6ds_lsm6dsox_mlc_test.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020 Bryan Siepert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# LSM6DSOX IMU MLC (Machine Learning Core) Example.
+# Download the raw UCF file, copy to storage and reset.
+
+# NOTE: The pre-trained models (UCF files) for the examples can be found here:
+# https://github.com/STMicroelectronics/STMems_Machine_Learning_Core/tree/master/application_examples/lsm6dsox
+
+import board
+from adafruit_lsm6ds.lsm6dsox import LSM6DSOX
+from adafruit_lsm6ds import Rate, AccelRange, GyroRange
+
+i2c = board.STEMMA_I2C()  # uses board.SCL and board.SDA
+
+
+# Vibration detection example
+UCF_FILE = "lsm6dsox_vibration_monitoring.ucf"
+UCF_LABELS = {0: "no vibration", 1: "low vibration", 2: "high vibration"}
+# NOTE: Selected data rate and scale must match the MLC data rate and scale.
+lsm = LSM6DSOX(i2c, ucf=UCF_FILE)
+lsm.gyro_range = GyroRange.RANGE_2000_DPS
+lsm.accelerometer_range = AccelRange.RANGE_4G
+lsm.accelerometer_data_rate = Rate.RATE_26_HZ
+lsm.gyro_data_rate = Rate.RATE_26_HZ
+# Head gestures example
+# UCF_FILE = "lsm6dsox_head_gestures.ucf"
+# UCF_LABELS = {0:"Nod", 1:"Shake", 2:"Stationary", 3:"Swing", 4:"Walk"}
+# NOTE: Selected data rate and scale must match the MLC data rate and scale.
+# lsm = LSM6DSOX(i2c, gyro_odr=26, accel_odr=26, gyro_scale=250, accel_scale=2, ucf=UCF_FILE)
+
+print("MLC configured...")
+
+while True:
+    buf = lsm.read_mlc_output()
+    if buf is not None:
+        print(UCF_LABELS[buf[0]])

--- a/examples/lsm6ds_lsm6dsox_simpletest.py
+++ b/examples/lsm6ds_lsm6dsox_simpletest.py
@@ -5,7 +5,7 @@ import time
 import board
 from adafruit_lsm6ds.lsm6dsox import LSM6DSOX
 
-i2c = board.I2C()  # uses board.SCL and board.SDA
+i2c = board.STEMMA_I2C()  # uses board.SCL and board.SDA
 sensor = LSM6DSOX(i2c)
 
 while True:

--- a/examples/lsm6ds_lsm6dsox_simpletest.py
+++ b/examples/lsm6ds_lsm6dsox_simpletest.py
@@ -5,7 +5,7 @@ import time
 import board
 from adafruit_lsm6ds.lsm6dsox import LSM6DSOX
 
-i2c = board.STEMMA_I2C()  # uses board.SCL and board.SDA
+i2c = board.I2C()  # uses board.SCL and board.SDA
 sensor = LSM6DSOX(i2c)
 
 while True:


### PR DESCRIPTION
Implement the ability to load "Machine Learning Core" configuration files to the LSM6DS0X -- see #51 
This is based on the MicroPython implementation https://github.com/micropython/micropython/tree/master/drivers/lsm6dsox
This allows for simple code to detect predetermined functions.
The Configuration files can be downloaded from https://github.com/STMicroelectronics/STMems_Machine_Learning_Core/tree/master/application_examples/lsm6dsox

an example program - lsm6ds_lsm6dsox_mlc_test.py shows how to use the vibration, head movement and 6DOF position examples.

This is only implemented for the LSM6DSOX.

Tested with an LSM6DSOX breakout (STEMMA)  on a feather rp2040.
