### PR TITLE
Add a short delay for the imu to start up

### DIFF
--- a/examples/lsm6ds_lsm6ds3trc_simpletest.py
+++ b/examples/lsm6ds_lsm6ds3trc_simpletest.py
@@ -12,6 +12,7 @@ from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC
 imupwr = digitalio.DigitalInOut(board.IMU_PWR)
 imupwr.direction = digitalio.Direction.OUTPUT
 imupwr.value = True
+time.sleep(0.1)
 
 imu_i2c = busio.I2C(board.IMU_SCL, board.IMU_SDA)
 sensor = LSM6DS3TRC(imu_i2c)


### PR DESCRIPTION
Otherwise is fails to start correctly on the Xiao Sense. Adding a short delay between power and the i2c seems to solve the issue nicely.