### PR TITLE
add low power mode

### DIFF
--- a/adafruit_lsm6ds/__init__.py
+++ b/adafruit_lsm6ds/__init__.py
@@ -345,6 +345,10 @@ class LSM6DS:
         if not Rate.is_valid(value):
             raise AttributeError("accelerometer_data_rate must be a `Rate`")
 
+        # ISM330DHCX requires enabling low-power mode for 1.6 Hz ODR
+        if value == Rate.RATE_1_6_HZ and getattr(self, "_supports_low_power_odr", False):
+            self.low_power_mode = True
+
         self._accel_data_rate = value
         # sleep(.2) # needed to let new range settle
 

--- a/adafruit_lsm6ds/ism330dhcx.py
+++ b/adafruit_lsm6ds/ism330dhcx.py
@@ -20,6 +20,7 @@ except ImportError:
 _LSM6DS_CTRL2_G = const(0x11)
 _ISM330DHCX_CTRL6_C = const(0x15)
 
+
 class ISM330DHCX(LSM6DS):
     """Driver for the ISM330DHCX 6-axis accelerometer and gyroscope.
 

--- a/adafruit_lsm6ds/ism330dhcx.py
+++ b/adafruit_lsm6ds/ism330dhcx.py
@@ -18,7 +18,7 @@ except ImportError:
     pass
 
 _LSM6DS_CTRL2_G = const(0x11)
-
+_ISM330DHCX_CTRL6_C = const(0x15)
 
 class ISM330DHCX(LSM6DS):
     """Driver for the ISM330DHCX 6-axis accelerometer and gyroscope.
@@ -56,6 +56,8 @@ class ISM330DHCX(LSM6DS):
 
     CHIP_ID = 0x6B
     _gyro_range_4000dps = RWBit(_LSM6DS_CTRL2_G, 0)
+    _supports_low_power_odr = True
+    low_power_mode = RWBit(_ISM330DHCX_CTRL6_C, 4)
 
     def __init__(self, i2c_bus: I2C, address: int = LSM6DS_DEFAULT_ADDRESS) -> None:
         GyroRange.add_values(


### PR DESCRIPTION
Small update to provide support for low-power mode. 

```python
sensor.accelerometer_data_rate = Rate.RATE_1_6_HZ
```

Based on [forum thread](https://forums.adafruit.com/viewtopic.php?t=221416).

Verified on:

| Component   | Details                         |
|------------|----------------------------------|
| Pi Model   | Pi 500 Plus                      |
| Pi OS      | Trixie 64-bit Lite               |
| Sensor     | Adafruit ISM330DHCX (#[4502](https://www.adafruit.com/product/4502))      |

Simple low power mode example:

```python
import time
import board
import busio
from adafruit_lsm6ds.ism330dhcx import ISM330DHCX
from adafruit_lsm6ds import AccelRange, Rate

i2c = busio.I2C(board.SCL, board.SDA)

# sensor init, set range, set low ODR, show mode
sensor = ISM330DHCX(i2c)
sensor.accelerometer_range = AccelRange.RANGE_2G
sensor.accelerometer_data_rate = Rate.RATE_1_6_HZ
print("LPM:", sensor.low_power_mode)

while True:
    ax, ay, az = sensor.acceleration
    print(f"{ax:.3f}, {ay:.3f}, {az:.3f}")
    time.sleep(1)
```
